### PR TITLE
chore: remove unnecessary labels from pull request creation step

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -148,10 +148,7 @@ jobs:
             
             ---
             *Created by [GitHub Actions workflow](.github/workflows/dependency-updates.yml)*
-          labels: |
-            dependencies
-            automated
-            chore
+          
           draft: false
           delete-branch: true
           


### PR DESCRIPTION
This pull request modifies the `.github/workflows/dependency-updates.yml` file to adjust the behavior of dependency update workflows. The most notable change is the removal of predefined labels for dependency update pull requests.

Workflow adjustments:

* [`.github/workflows/dependency-updates.yml`](diffhunk://#diff-d038ebbb119f6f82184473fded4cf37e956c9ac5dd2a67d8504050eb105726d3L151-R151): Removed the `labels` field, which previously assigned the labels `dependencies`, `automated`, and `chore` to dependency update pull requests.