### PR TITLE
Fix automatic language detection in app

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', {

--- a/src/__tests__/HtmlLanguageAttribute.test.tsx
+++ b/src/__tests__/HtmlLanguageAttribute.test.tsx
@@ -19,7 +19,7 @@ describe('HtmlLanguageAttribute', () => {
     jest.clearAllMocks();
   });
 
-  it('sets document.documentElement.lang based on currentLanguage (first 2 chars)', async () => {
+  it('sets document.documentElement.lang to default full locale based on currentLanguage', async () => {
     useLanguageMock.mockReturnValue({
       currentLanguage: 'en-US',
     });
@@ -30,9 +30,8 @@ describe('HtmlLanguageAttribute', () => {
       </HtmlLanguageAttribute>
     );
 
-    // Effect runs asynchronously
     await waitFor(() => {
-      expect(document.documentElement.lang).toBe('en');
+      expect(document.documentElement.lang).toBe('en-US');
     });
   });
 
@@ -59,9 +58,9 @@ describe('HtmlLanguageAttribute', () => {
         </HtmlLanguageAttribute>
       );
 
-      // Two effects run: first sets 'en', second (first-time visitor) sets 'nl'
+      // Two effects run: first sets default from currentLanguage, then first-time visitor logic sets 'nl-NL'
       await waitFor(() => {
-        expect(document.documentElement.lang).toBe('nl');
+        expect(document.documentElement.lang).toBe('nl-NL');
       });
     } finally {
       // Restore navigator.language

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { I18nProvider } from "@/components/I18nProvider";
 import { HtmlLanguageAttribute } from "@/components/HtmlLanguageAttribute";
+import { headers } from "next/headers";
 
 export const metadata: Metadata = {
   title: "QCode - Kortingscodes Beheren",
@@ -29,8 +30,22 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const h = headers();
+  const acceptLanguage = h.get('accept-language') || '';
+  const parseDefaultLocale = (accept: string): string => {
+    const parts = accept.split(',').map(p => p.split(';')[0].trim()).filter(Boolean);
+    // Find first with base 'nl' or 'en'
+    for (const p of parts) {
+      const base = p.split('-')[0];
+      if (base === 'nl') return 'nl-NL';
+      if (base === 'en') return 'en-US';
+    }
+    return 'en-US';
+  };
+  const ssrLang = parseDefaultLocale(acceptLanguage);
+
   return (
-    <html>
+    <html lang={ssrLang}>
       <body
         className={`font-sans antialiased min-h-screen transition-colors`}
       >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,12 +25,12 @@ export const viewport: Viewport = {
   themeColor: "#3b82f6",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const h = headers();
+  const h = await headers();
   const acceptLanguage = h.get('accept-language') || '';
   const parseDefaultLocale = (accept: string): string => {
     const parts = accept.split(',').map(p => p.split(';')[0].trim()).filter(Boolean);

--- a/src/components/HtmlLanguageAttribute.tsx
+++ b/src/components/HtmlLanguageAttribute.tsx
@@ -6,11 +6,15 @@ import { useLanguage } from '@/hooks/useLanguage'
 export function HtmlLanguageAttribute({ children }: { children: React.ReactNode }) {
   const { currentLanguage } = useLanguage()
   
+  const resolveDefaultLocale = (lang: string): string => {
+    const base = lang.substring(0, 2)
+    if (base === 'nl') return 'nl-NL'
+    return 'en-US'
+  }
+  
   // Use the Effect hook to update the HTML lang attribute only on the client side
   useEffect(() => {
-    // Get the first 2 chars (e.g., "en" from "en-US")
-    const langCode = currentLanguage.substring(0, 2)
-    document.documentElement.lang = langCode
+    document.documentElement.lang = resolveDefaultLocale(currentLanguage)
   }, [currentLanguage])
 
   // Also set initial language on mount for first-time visitors
@@ -22,7 +26,7 @@ export function HtmlLanguageAttribute({ children }: { children: React.ReactNode 
       if (!savedLanguage) {
         const browserLang = navigator.language.split('-')[0];
         const supportedLanguage = ['en', 'nl'].includes(browserLang) ? browserLang : 'en';
-        document.documentElement.lang = supportedLanguage;
+        document.documentElement.lang = resolveDefaultLocale(supportedLanguage);
       }
     }
   }, [])

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -29,19 +29,8 @@ if (!i18n.isInitialized) {
       lng: 'en', // Default language for SSR
     });
 
-  // Add language detector only on client side
+  // Client-side: apply saved or detected language without re-initializing i18n
   if (isBrowser) {
-    import('i18next-browser-languagedetector').then((LanguageDetector) => {
-      i18n.use(LanguageDetector.default);
-      i18n.init({
-        detection: {
-          order: ['localStorage', 'navigator'],
-          caches: ['localStorage'],
-        },
-      });
-    });
-
-    // Try to load saved language preference
     const savedLanguage = localStorage.getItem('qcode-language');
     if (savedLanguage === 'auto') {
       const browserLang = navigator.language.split('-')[0];


### PR DESCRIPTION
Fix automatic language detection to apply locale immediately on settings open.

The previous setup had a race condition where `i18next-browser-languagedetector` re-initialized i18n on the client, overriding our explicit "auto" language detection logic. This resulted in the UI showing "Automatic" but not switching to the user's locale until "Automatic" was clicked. This PR removes the redundant re-initialization, ensuring the correct language is applied immediately on mount based on saved preference or browser locale.

---
<a href="https://cursor.com/background-agent?bcId=bc-af82939f-de3e-4696-9839-a43fa11c2946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af82939f-de3e-4696-9839-a43fa11c2946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

